### PR TITLE
hotfix: permit all request to authentication endpoints

### DIFF
--- a/backend/src/main/java/com/kuizu/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kuizu/backend/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));


### PR DESCRIPTION
In order for login or register to work, we must allow unauthenticated access to the authentication endpoints